### PR TITLE
backdrop css update to hide the scrollbar on exit

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -106,6 +106,7 @@ button {
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow-y: hidden;
 }
 
 .modal {


### PR DESCRIPTION
Added `overflow-y: hidden` to the backdrop to hide the scrollbar on exit animation.